### PR TITLE
Add a link to Deprecated library

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ based on declaring commands through decorators. You can also check out the
 parallelizes Python programs, and requires minimal modifications to existing serial programs.
 - [decorator](https://github.com/micheles/decorator) This is your best option if you want to preserve the signature of
 decorated functions in a consistent way across Python releases.
+- [deprecated](https://github.com/tantale/deprecated) Use `@deprecated` decorator to deprecate old python classes,
+  functions or methods. Decorators can also be used to add Sphinx directives.
 - [fasteners](https://github.com/harlowja/fasteners) Provides useful locks and decorators to lock/unlock around functions and methods.
 - [flask](https://github.com/mitsuhiko/flask) Flask is a micro web framework in python, which uses decorators to route
 the URL, register error handler, register processor and so on.


### PR DESCRIPTION
Hi,

Can you add a link to the Python [deprecated](https://github.com/tantale/deprecated) library.

Use `@deprecated` decorator to deprecate old python classes, functions or methods. Decorators can also be used to add Sphinx directives.

Regards,
– Laurent.